### PR TITLE
Update script-transfer-hbar.js and utils.js

### DIFF
--- a/util/util.js
+++ b/util/util.js
@@ -33,6 +33,9 @@ const ANSI = {
     FG_PURPLE: '\x1b[35m',
     FG_CYAN: '\x1b[36m',
     FG_DEFAULT: '\x1b[39m',
+    CLEAR_LINE: '\x1b[2K',
+    CURSOR_UP_1: '\x1b[1A',
+    CURSOR_LEFT_MAX: '\x1b[9999D',
 };
 const CHARS = {
     HELLIP: '…',
@@ -112,6 +115,7 @@ async function createLogger({
     }
 
     function logSection(...strings) {
+        console.log();
         return log(...applyAnsi('SECTION', ...strings));
     }
 
@@ -124,6 +128,7 @@ async function createLogger({
         });
         await rlPrompt.question('(Hit the "return" key when ready to proceed)');
         rlPrompt.close();
+        stdout.write(ANSI.CURSOR_UP_1 + ANSI.CLEAR_LINE + ANSI.CURSOR_LEFT_MAX);
         return retVal;
     }
 
@@ -183,6 +188,7 @@ async function createLogger({
         await metricsTrackOnHcs(logger, msg);
         await writeLoggerFile(logger);
         await gracefullyCloseClient();
+        console.log();
         return log(...applyAnsi('ERROR', 'Error ID:', msg.detail), '\n', ...strings);
     }
 


### PR DESCRIPTION
- updates the `util.js` file with code to remove the prompt lines after input using ANSI escape code
- adds a newline after each console log section in `script-transfer-hbar.js` 

the output of the updated code in this PR:

```bash
🟣 Creating, signing, and submitting the transfer transaction  …
The transfer transaction ID: 0.0.1@1722480248.302344195
The transfer transaction status is: SUCCESS
The new account balance after the transfer: 346.74689935 ℏ 

🟣 View the transfer transaction transaction in HashScan  …
Copy and paste this URL in your browser:
 https://hashscan.io/testnet/transaction/0.0.1@1722480248.302344195 

🟣 Get transfer transaction data from the Hedera Mirror Node  …
The transfer transaction Hedera Mirror Node API URL:
 https://testnet.mirrornode.hedera.com/api/v1/transactions/0.0.1-1722480248-302344195?nonce=0
The debit and credit amounts of the transfer transaction:
 [
  '10 ℏ',
  '0.00006457 ℏ',
  '0.00137583 ℏ',
  '0.00015286 ℏ',
  '-10.00159326 ℏ'
] 

```